### PR TITLE
fix: support Node >=14, not >=18

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,6 @@
 	},
 	"packageManager": "pnpm@7.31.0",
 	"engines": {
-		"node": ">=18"
+		"node": ">=14"
 	}
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #25
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/are-docs-informative/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/are-docs-informative/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Bumps the engine requirement in `package.json`.
